### PR TITLE
fix Hash_set when used with previously seen key

### DIFF
--- a/satan.c
+++ b/satan.c
@@ -19,6 +19,14 @@ void Hash_init(Hash *h)
 void Hash_set(Hash *h, int key, int val)
 {
 	Value v;
+	int i;
+	
+	for (i = 0; i < h->size; ++i)
+		if (h->elems[i].key == key) {
+			h->elems[i].val = val;
+			return;
+		}
+	
 	v.key = key;
 	v.val = val;
 


### PR DESCRIPTION
Hash_set didn't check whether the given key already exists or not. This caused no problems with calls and labels, but when used with STORE instruction to address the same memory slot repeatedly, the returned value was always the first one written.

Hash_set now correctly works even if previously used key is repeatedly set, which fixes the STORE instruction.